### PR TITLE
chore: remove pnpm-workspace.yaml file

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,0 @@
-ignoredBuiltDependencies:
-  - '@firebase/util'
-  - core-js
-  - esbuild
-  - protobufjs
-  - sharp


### PR DESCRIPTION
The file contained ignored built dependencies that are no longer needed for the workspace configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency handling configuration to ensure critical dependencies are properly installed and processed according to standard resolution rules during build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->