### PR TITLE
refactor(theme-provider): derive props type from component

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,10 @@
 "use client";
-import {
-  ThemeProvider as NextThemesProvider,
-  ThemeProviderProps,
-} from "next-themes";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+// Derive props type from the actual ThemeProvider component
+type ThemeProviderProps = ComponentProps<typeof NextThemesProvider>;
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>;


### PR DESCRIPTION
Use React's ComponentProps to type ThemeProviderProps instead of importing from next-themes for better type safety and consistency with React patterns.