### PR TITLE
fix(payment): cancel existing pending subscriptions before new creation

### DIFF
--- a/app/api/payment/subscribe/route.ts
+++ b/app/api/payment/subscribe/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { dbAdmin } from "../../../../lib/firebase-admin";
+import { cancelAllPendingSubscriptions } from "../../../../lib/subscription-utils";
 
 export async function POST(req: NextRequest) {
   try {
@@ -41,6 +42,9 @@ export async function POST(req: NextRequest) {
         error: "User already has an active subscription" 
       }, { status: 400 });
     }
+
+    // Cancel any existing pending subscriptions to avoid accumulation
+    await cancelAllPendingSubscriptions(userId);
 
     const txRef = `sub-${userId}-${Date.now()}`;
 

--- a/lib/subscription-utils.ts
+++ b/lib/subscription-utils.ts
@@ -201,6 +201,7 @@ export async function cancelPendingSubscription(txRef: string) {
     if (!subscriptionQuery.empty) {
       await subscriptionQuery.docs[0].ref.update({
         status: "cancelled",
+        cancelledAt: new Date(),
         updatedAt: new Date(),
       });
       console.log(`Pending subscription ${txRef} cancelled`);
@@ -209,6 +210,37 @@ export async function cancelPendingSubscription(txRef: string) {
     return false;
   } catch (error) {
     console.error("Error cancelling pending subscription:", error);
+    throw error;
+  }
+}
+
+export async function cancelAllPendingSubscriptions(userId: string) {
+  try {
+    const pendingSubscriptions = await dbAdmin
+      .collection("subscriptions")
+      .where("userId", "==", userId)
+      .where("status", "==", "pending")
+      .get();
+
+    if (pendingSubscriptions.empty) {
+      return 0;
+    }
+
+    const batch = dbAdmin.batch();
+    pendingSubscriptions.docs.forEach((doc) => {
+      batch.update(doc.ref, {
+        status: "cancelled",
+        reason: "New subscription initiated",
+        cancelledAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+
+    await batch.commit();
+    console.log(`Cancelled ${pendingSubscriptions.size} pending subscriptions for user ${userId}`);
+    return pendingSubscriptions.size;
+  } catch (error) {
+    console.error("Error cancelling all pending subscriptions:", error);
     throw error;
   }
 }


### PR DESCRIPTION
Add cancelAllPendingSubscriptions utility to prevent accumulation of pending subscriptions when users initiate new subscriptions. This ensures only one active subscription process exists per user and adds cancelledAt timestamp for better tracking.